### PR TITLE
fix(api): query latest salad

### DIFF
--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -24,15 +24,10 @@ app.use(express.json());
 
 // TODO - handle fetching errors
 app.get('/', async (_req, res) => {
-  // salads.date column is a postgres current_date fn, which formats dates as 'YYYY-MM-DD 00:00:00'
-  const current_date = new Date();
-  const yyyyMmDd = current_date.toISOString().split('T')[0];
-  const formatted = `${yyyyMmDd} 00:00:00`;
   const { rows } = await query({
-    text: 'select * from salads where salads.date = $1',
-    params: [formatted],
+    text: 'select * from salads order by salad_number desc limit 1',
   });
-  // while in dev mode, allow multiple games per day
+  // get the last entry from the query
   const latestSalad = rows[rows.length - 1];
   if (latestSalad) {
     res.send({ salad: latestSalad });


### PR DESCRIPTION
Quick fix to the api to query postgres for the latest salad, instead of scoping it to the date